### PR TITLE
build: add full build option to document solution when there are missing posts

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,6 +5,13 @@ set -o xtrace
 git submodule init
 git pull --recurse-submodules
 
+JEKYLL_COMMAND="jekyll serve --host 0.0.0.0 --future --drafts --watch --force_polling"
+# if 'full' is passed, don't add '--incremental'` flag
+# use this if you encounter rendering issues (e.g. missing posts on the homepage)
+if [ "$1" != "full" ]; then
+  JEKYLL_COMMAND="$JEKYLL_COMMAND --incremental"
+fi
+
 # run local jekyll server; will be served at http://localhost:4000
 # latest version from https://github.com/github/pages-gem/releases
 export GITHUB_PAGES_GEM_VERSION=v232
@@ -12,4 +19,4 @@ docker run --rm \
   --volume="$PWD:/src/site" -p 4000:4000 \
   --env JEKYLL_UID=$(id -u) --env JEKYLL_GID=$(id -g) \
   -it ghcr.io/github/pages-gem:$GITHUB_PAGES_GEM_VERSION \
-  jekyll serve --host 0.0.0.0 --future --drafts --watch --force_polling --incremental
+  sh -c "$JEKYLL_COMMAND"


### PR DESCRIPTION
I was testing something using an existing checkout of the project and noticed that my local build would not render recent pages on the homepage even though the posts were accessible directly. This was due to stale build cache used in the incremental build. 

I've added a {{./build.sh full}} parameter to serve as documentation in case this "issue" comes up again. The default build remains incremental for speed.

```sh
$ ./build.sh full
+ git submodule init
+ git pull --recurse-submodules
Fetching submodule reveal.js
Already up to date.
+ JEKYLL_COMMAND=jekyll serve --host 0.0.0.0 --future --drafts --watch --force_polling
+ [ full != full ]
+ export GITHUB_PAGES_GEM_VERSION=v232
+ id -u
+ id -g
+ docker run --rm --volume=/home/lucasrangit/projects/bhnt.c-base.org:/src/site -p 4000:4000 --env JEKYLL_UID=1000 --env JEKYLL_GID=1000 -it ghcr.io/github/pages-gem:v232 sh -c jekyll serve --host 0.0.0.0 --future --drafts --watch --force_polling
Configuration file: /src/site/_config.yml
            Source: /src/site
       Destination: /src/site/_site
 Incremental build: disabled. Enable with --incremental
      Generating... 
                    done in 2.812 seconds.
 Auto-regeneration: enabled for '/src/site'
    Server address: http://0.0.0.0:4000
  Server running... press ctrl-c to stop.
^C

$ ./build.sh 
+ git submodule init
+ git pull --recurse-submodules
Fetching submodule reveal.js
Already up to date.
+ JEKYLL_COMMAND=jekyll serve --host 0.0.0.0 --future --drafts --watch --force_polling
+ [  != full ]
+ JEKYLL_COMMAND=jekyll serve --host 0.0.0.0 --future --drafts --watch --force_polling --incremental
+ export GITHUB_PAGES_GEM_VERSION=v232
+ id -u
+ id -g
+ docker run --rm --volume=/home/lucasrangit/projects/bhnt.c-base.org:/src/site -p 4000:4000 --env JEKYLL_UID=1000 --env JEKYLL_GID=1000 -it ghcr.io/github/pages-gem:v232 sh -c jekyll serve --host 0.0.0.0 --future --drafts --watch --force_polling --incremental
Configuration file: /src/site/_config.yml
            Source: /src/site
       Destination: /src/site/_site
 Incremental build: enabled
      Generating... 
                    done in 2.78 seconds.
 Auto-regeneration: enabled for '/src/site'
    Server address: http://0.0.0.0:4000
  Server running... press ctrl-c to stop.
```